### PR TITLE
fix: notes from the future

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -12,7 +12,7 @@
 const ESLintPlugin = require('eslint-webpack-plugin')
 
 
-const { configure } = require('quasar/wrappers');
+const { configure } = require('quasar/wrappers')
 
 module.exports = configure(function (ctx) {
   return {
@@ -230,8 +230,6 @@ module.exports = configure(function (ctx) {
           .use(ESLintPlugin, [{ extensions: [ 'js' ] }])
       },
 
-
-
       chainWebpackPreload (chain) {
         chain.plugin('eslint-webpack-plugin')
           .use(ESLintPlugin, [{ extensions: [ 'js' ] }])
@@ -239,4 +237,4 @@ module.exports = configure(function (ctx) {
 
     }
   }
-});
+})

--- a/src/components/Feed/Feed.vue
+++ b/src/components/Feed/Feed.vue
@@ -31,6 +31,12 @@ import DateUtils from 'src/utils/DateUtils'
 import Bots from 'src/utils/bots'
 
 const feedOrder = (a, b) => b[0].createdAt - a[0].createdAt
+const maxDate = (max) => (note) => {
+  if (note.createdAt > max)
+    note.createdAt = max
+  return note
+}
+const now = () => new Date().getTime() / 1000
 
 const MAX_ITEMS_VISIBLE = 25
 
@@ -94,7 +100,8 @@ export default {
         const items = notes
           .concat(data)
           .filter((note) => this.filterNote(note, this.feed.hideBots))
-          .map((note) => [note]) // TODO Single element thread
+          .map(maxDate(now()))
+          .map(note => [note]) // TODO Single element thread
           .sort(feedOrder)
           .filter(
             (item, pos, array) => !pos || item[0].id !== array[pos - 1][0].id
@@ -110,6 +117,7 @@ export default {
       })
       this.stream.on('update', (note) => {
         if (!this.filterNote(note, this.feed.hideBots)) return
+        note = maxDate(now())(note)
         if (note.createdAt >= this.timestampNewest) {
           this.newer.push([note]) // TODO Single element thread
         } else if (note.createdAt >= this.timestampOldest) {


### PR DESCRIPTION
## Scope

This PR aims to make the minimum changes needed to handle future notes. 

Closes #38 

## Implementation

Two new functions are defined; a deterministic function that modifies the timestamp of the note to be no more than a maximum date, and a helper function to return the current time in the same format as the timestamp of the note.

The two functions are applied to the initial set of notes and subsequently on every new note from the feed.

